### PR TITLE
Bump consumers and adapt latest task to new model

### DIFF
--- a/config/migrations/2022/20221117180111-convert-latest-besluiten-task-to-new-model.sparql
+++ b/config/migrations/2022/20221117180111-convert-latest-besluiten-task-to-new-model.sparql
@@ -1,0 +1,60 @@
+# While updating the most recent delta sync task of each type, we ensure a smooth transition to the new consumer.
+# Only doing it on the most recent task because the query is too heavy otherwise
+
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX task: <http://redpencil.data.gift/vocabularies/tasks/>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX oslc: <http://open-services.net/ns/core#>
+PREFIX cogs: <http://vocab.deri.ie/cogs#>
+PREFIX adms: <http://www.w3.org/ns/adms#>
+PREFIX nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#>
+PREFIX dbpedia: <http://dbpedia.org/resource/>
+
+INSERT {
+  GRAPH ?g {
+    ?job a <http://vocab.deri.ie/cogs#Job> ;
+      mu:uuid ?uuidJob ;
+      adms:status <http://redpencil.data.gift/id/concept/JobStatus/success> ;
+      dct:created ?created ;
+      dct:modified ?created ;
+      task:operation ?operation ;
+      dct:creator ?creator .
+
+    ?task a task:Task ;
+      task:index "0" ;
+      dct:modified ?created ;
+      dct:isPartOf ?job ;
+      adms:status <http://redpencil.data.gift/id/concept/JobStatus/success> ;
+      task:operation <http://redpencil.data.gift/id/jobs/concept/TaskOperation/deltas/consumer/deltaSyncing> ;
+      task:resultsContainer ?resultsContainer.
+
+    ?resultsContainer a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+      mu:uuid ?uuidResultsContainer ;
+      dct:subject <http://redpencil.data.gift/id/concept/DeltaSync/DeltafileInfo>;
+      ext:hasDeltafileTimestamp ?deltaTimestamp.
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?task a ext:SyncTask ;
+      mu:uuid ?uuid ;
+      adms:status <http://lblod.data.gift/sync-task-statuses/success> ;
+      dct:created ?created ;
+      dct:creator ?creator ;
+      ext:deltaUntil ?deltaTimestamp .
+  }
+
+  VALUES (?creator ?operation) {
+    (<http://data.lblod.info/services/id/besluiten-consumer> <http://redpencil.data.gift/id/jobs/concept/JobOperation/deltas/consumer/besluitenSyncing>)
+  }
+
+  BIND(MD5(CONCAT(?task, "job")) as ?uuidJob)
+  BIND(MD5(CONCAT(?task, "resultsContainer")) as ?uuidResultsContainer)
+  BIND(IRI(CONCAT("http://redpencil.data.gift/id/job/", ?uuidJob)) AS ?job)
+  BIND(IRI(CONCAT("http://data.lblod.info/id/dataContainers/", ?uuidResultsContainer)) AS ?resultsContainer)
+}
+ORDER BY DESC(?created)
+LIMIT 1

--- a/config/migrations/2022/20221117180112-convert-latest-mandaten-task-to-new-model.sparql
+++ b/config/migrations/2022/20221117180112-convert-latest-mandaten-task-to-new-model.sparql
@@ -1,0 +1,61 @@
+# While updating the most recent delta sync task of each type, we ensure a smooth transition to the new consumer.
+# Only doing it on the most recent task because the query is too heavy otherwise
+
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX task: <http://redpencil.data.gift/vocabularies/tasks/>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX oslc: <http://open-services.net/ns/core#>
+PREFIX cogs: <http://vocab.deri.ie/cogs#>
+PREFIX adms: <http://www.w3.org/ns/adms#>
+PREFIX nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#>
+PREFIX dbpedia: <http://dbpedia.org/resource/>
+
+INSERT {
+  GRAPH ?g {
+    ?job a <http://vocab.deri.ie/cogs#Job> ;
+      mu:uuid ?uuidJob ;
+      adms:status <http://redpencil.data.gift/id/concept/JobStatus/success> ;
+      dct:created ?created ;
+      dct:modified ?created ;
+      task:operation ?operation ;
+      dct:creator ?creator .
+
+    ?task a task:Task ;
+      task:index "0" ;
+      dct:modified ?created ;
+      dct:isPartOf ?job ;
+      adms:status <http://redpencil.data.gift/id/concept/JobStatus/success> ;
+      task:operation <http://redpencil.data.gift/id/jobs/concept/TaskOperation/deltas/consumer/deltaSyncing> ;
+      task:resultsContainer ?resultsContainer.
+
+    ?resultsContainer a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+      mu:uuid ?uuidResultsContainer ;
+      dct:subject <http://redpencil.data.gift/id/concept/DeltaSync/DeltafileInfo>;
+      ext:hasDeltafileTimestamp ?deltaTimestamp.
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?task a ext:SyncTask ;
+      mu:uuid ?uuid ;
+      adms:status <http://lblod.data.gift/sync-task-statuses/success> ;
+      dct:created ?created ;
+      dct:creator ?creator ;
+      ext:deltaUntil ?deltaTimestamp .
+  }
+
+
+  VALUES (?creator ?operation) {
+    (<http://data.lblod.info/services/id/mandatendatabank-consumer> <http://redpencil.data.gift/id/jobs/concept/JobOperation/deltas/consumer/mandatarissenSyncing>)
+  }
+
+  BIND(MD5(CONCAT(?task, "job")) as ?uuidJob)
+  BIND(MD5(CONCAT(?task, "resultsContainer")) as ?uuidResultsContainer)
+  BIND(IRI(CONCAT("http://redpencil.data.gift/id/job/", ?uuidJob)) AS ?job)
+  BIND(IRI(CONCAT("http://data.lblod.info/id/dataContainers/", ?uuidResultsContainer)) AS ?resultsContainer)
+}
+ORDER BY DESC(?created)
+LIMIT 1

--- a/config/migrations/2022/20221117180113-convert-latest-leidinggevenden-task-to-new-model.sparql
+++ b/config/migrations/2022/20221117180113-convert-latest-leidinggevenden-task-to-new-model.sparql
@@ -1,0 +1,60 @@
+# While updating the most recent delta sync task of each type, we ensure a smooth transition to the new consumer.
+# Only doing it on the most recent task because the query is too heavy otherwise
+
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX task: <http://redpencil.data.gift/vocabularies/tasks/>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX oslc: <http://open-services.net/ns/core#>
+PREFIX cogs: <http://vocab.deri.ie/cogs#>
+PREFIX adms: <http://www.w3.org/ns/adms#>
+PREFIX nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#>
+PREFIX dbpedia: <http://dbpedia.org/resource/>
+
+INSERT {
+  GRAPH ?g {
+    ?job a <http://vocab.deri.ie/cogs#Job> ;
+      mu:uuid ?uuidJob ;
+      adms:status <http://redpencil.data.gift/id/concept/JobStatus/success> ;
+      dct:created ?created ;
+      dct:modified ?created ;
+      task:operation ?operation ;
+      dct:creator ?creator .
+
+    ?task a task:Task ;
+      task:index "0" ;
+      dct:modified ?created ;
+      dct:isPartOf ?job ;
+      adms:status <http://redpencil.data.gift/id/concept/JobStatus/success> ;
+      task:operation <http://redpencil.data.gift/id/jobs/concept/TaskOperation/deltas/consumer/deltaSyncing> ;
+      task:resultsContainer ?resultsContainer.
+
+    ?resultsContainer a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer>;
+      mu:uuid ?uuidResultsContainer ;
+      dct:subject <http://redpencil.data.gift/id/concept/DeltaSync/DeltafileInfo>;
+      ext:hasDeltafileTimestamp ?deltaTimestamp.
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?task a ext:SyncTask ;
+      mu:uuid ?uuid ;
+      adms:status <http://lblod.data.gift/sync-task-statuses/success> ;
+      dct:created ?created ;
+      dct:creator ?creator ;
+      ext:deltaUntil ?deltaTimestamp .
+  }
+
+  VALUES (?creator ?operation) {
+    (<http://data.lblod.info/services/id/leidinggevenden-consumer> <http://redpencil.data.gift/id/jobs/concept/JobOperation/deltas/consumer/leidinggevendenSyncing>)
+  }
+
+  BIND(MD5(CONCAT(?task, "job")) as ?uuidJob)
+  BIND(MD5(CONCAT(?task, "resultsContainer")) as ?uuidResultsContainer)
+  BIND(IRI(CONCAT("http://redpencil.data.gift/id/job/", ?uuidJob)) AS ?job)
+  BIND(IRI(CONCAT("http://data.lblod.info/id/dataContainers/", ?uuidResultsContainer)) AS ?resultsContainer)
+}
+ORDER BY DESC(?created)
+LIMIT 1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -152,18 +152,20 @@ services:
     volumes:
       - ./config/delta-consumer/report-generator:/config
   mandatendatabank-consumer:
-      image: lblod/delta-consumer-single-graph-maintainer:0.4.1
+      image: lblod/delta-consumer:0.0.10
       environment:
-        SYNC_BASE_URL: 'https://loket.lblod.info/'
-        SERVICE_NAME: 'mandatendatabank-consumer'
-        SYNC_FILES_PATH: '/sync/mandatarissen/files'
-        SYNC_DATASET_SUBJECT: "http://data.lblod.info/datasets/delta-producer/dumps/MandatarissenCacheGraphDump"
-        INITIAL_SYNC_JOB_OPERATION: "http://redpencil.data.gift/id/jobs/concept/JobOperation/deltas/consumer/initialSync/mandatarissen"
-        JOB_CREATOR_URI: "http://data.lblod.info/services/id/mandatendatabank-consumer"
-        DISABLE_INITIAL_SYNC: 'true'
+        DCR_SYNC_BASE_URL: "https://loket.lblod.info/"
+        DCR_SERVICE_NAME: "mandatendatabank-consumer"
+        DCR_SYNC_FILES_PATH: "/sync/mandatarissen/files"
+        DCR_SYNC_DATASET_SUBJECT: "http://data.lblod.info/datasets/delta-producer/dumps/lblod-harvester/MandatarissenCacheGraphDump"
+        DCR_INITIAL_SYNC_JOB_OPERATION: "http://redpencil.data.gift/id/jobs/concept/JobOperation/deltas/consumer/initialSync/mandatarissen"
+        DCR_DELTA_SYNC_JOB_OPERATION: "http://redpencil.data.gift/id/jobs/concept/JobOperation/deltas/consumer/mandatarissenSyncing"
+        DCR_JOB_CREATOR_URI: "http://data.lblod.info/services/id/mandatendatabank-consumer"
+        DCR_KEEP_DELTA_FILES: "true"
+        DCR_DELTA_FILE_FOLDER: "/consumer-files"
+        DCR_DISABLE_INITIAL_SYNC: "true"
         BYPASS_MU_AUTH_FOR_EXPENSIVE_QUERIES: 'true'
-        KEEP_DELTA_FILES: 'true'
-        DELTA_FILE_FOLDER: '/consumer-files'
+        BATCH_SIZE: 1000
       volumes:
         - ./data/files/consumer-files/mandaten:/consumer-files/
       restart: always
@@ -171,37 +173,40 @@ services:
         - "logging=true"
       logging: *default-logging
   leidinggevenden-consumer:
-    image: lblod/delta-consumer-single-graph-maintainer:0.4.1
+    image: lblod/delta-consumer:0.0.10
     environment:
-      SYNC_BASE_URL: 'https://loket.lblod.info' # replace with link to Loket API
-      SERVICE_NAME: 'leidinggevenden-consumer'
-      SYNC_FILES_PATH: '/sync/leidinggevenden/files'
-      SYNC_DATASET_SUBJECT: "http://data.lblod.info/datasets/delta-producer/dumps/LeidinggevendenCacheGraphDump"
-      INITIAL_SYNC_JOB_OPERATION: "http://redpencil.data.gift/id/jobs/concept/JobOperation/deltas/consumer/initialSync/leidinggevenden"
-      JOB_CREATOR_URI: "http://data.lblod.info/services/id/leidinggevenden-consumer"
-      DISABLE_INITIAL_SYNC: 'true'
+      DCR_SYNC_BASE_URL: "https://loket.lblod.info/"
+      DCR_SERVICE_NAME: "leidinggevenden-consumer"
+      DCR_SYNC_FILES_PATH: "/sync/leidinggevenden/files"
+      DCR_SYNC_DATASET_SUBJECT: "http://data.lblod.info/datasets/delta-producer/dumps/lblod-harvester/LeidinggevendenCacheGraphDump"
+      DCR_INITIAL_SYNC_JOB_OPERATION: "http://redpencil.data.gift/id/jobs/concept/JobOperation/deltas/consumer/initialSync/leidinggevenden"
+      DCR_DELTA_SYNC_JOB_OPERATION: "http://redpencil.data.gift/id/jobs/concept/JobOperation/deltas/consumer/leidinggevendenSyncing"
+      DCR_JOB_CREATOR_URI: "http://data.lblod.info/services/id/leidinggevenden-consumer"
+      DCR_KEEP_DELTA_FILES: "true"
+      DCR_DELTA_FILE_FOLDER: "/consumer-files"
+      DCR_DISABLE_INITIAL_SYNC: "true"
       BYPASS_MU_AUTH_FOR_EXPENSIVE_QUERIES: 'true'
-      KEEP_DELTA_FILES: 'true'
-      DELTA_FILE_FOLDER: '/consumer-files'
+      BATCH_SIZE: 1000
     volumes:
       - ./data/files/consumer-files/leidinggevenden:/consumer-files/
     restart: always
     labels:
       - "logging=true"
   besluiten-consumer:
-    image: lblod/delta-consumer-single-graph-maintainer:0.4.1
+    image: lblod/delta-consumer:0.0.10
     environment:
-      SYNC_BASE_URL: 'https://dev.harvesting-self-service.lblod.info' # replace with link to Loket API
-      SERVICE_NAME: 'besluiten-consumer'
-      SYNC_FILES_PATH: '/sync/besluiten/files'
-      SYNC_DATASET_SUBJECT: "http://data.lblod.info/datasets/delta-producer/dumps/lblod-harvester/BesluitenCacheGraphDump"
-      INITIAL_SYNC_JOB_OPERATION: "http://redpencil.data.gift/id/jobs/concept/JobOperation/deltas/consumer/initialSync/besluiten"
-      JOB_CREATOR_URI: "http://data.lblod.info/services/id/besluiten-consumer"
-      DISABLE_INITIAL_SYNC: 'true'
+      DCR_SYNC_BASE_URL: "https://dev.harvesting-self-service.lblod.info/"
+      DCR_SERVICE_NAME: "besluiten-consumer"
+      DCR_SYNC_FILES_PATH: "/sync/besluiten/files"
+      DCR_SYNC_DATASET_SUBJECT: "http://data.lblod.info/datasets/delta-producer/dumps/lblod-harvester/BesluitenCacheGraphDump"
+      DCR_INITIAL_SYNC_JOB_OPERATION: "http://redpencil.data.gift/id/jobs/concept/JobOperation/deltas/consumer/initialSync/besluiten"
+      DCR_DELTA_SYNC_JOB_OPERATION: "http://redpencil.data.gift/id/jobs/concept/JobOperation/deltas/consumer/besluitenSyncing"
+      DCR_JOB_CREATOR_URI: "http://data.lblod.info/services/id/besluiten-consumer"
+      DCR_KEEP_DELTA_FILES: "true"
+      DCR_DELTA_FILE_FOLDER: "/consumer-files"
+      DCR_DISABLE_INITIAL_SYNC: "true" # toggle this in override, leave 'true' in default docker-compose.yml
       BYPASS_MU_AUTH_FOR_EXPENSIVE_QUERIES: 'true'
-      KEEP_DELTA_FILES: 'true'
-      DELTA_FILE_FOLDER: '/consumer-files'
-      BATCH_SIZE: 100 # if virtuoso is in prod mode, you can safely beef this up to 500/1000
+      BATCH_SIZE: 1000
     volumes:
       - ./data/files/consumer-files/besluiten:/consumer-files/
     restart: always


### PR DESCRIPTION
In this PR I'm bumping all the consumers to `delta-consumer` in the way Felix did in QA for the decisions.

I also created migrations that take the most recent successful delta sync task and update it to comply with the model of the new service. That way, the new consumer will know from when it had to take over.

I split it in 3 files because for some reason the `;` split wasn't working properly. But like that I was able to get it working