### PR TITLE
Bugfix/betrokken besturen not flushed during delta initial sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## Unreleased
+### Erediensten
+  - flush, rerun op sync migrations to fix typeBetrokkenheid
+### Deploy instructions
+  - re-sync erediensten from OP
 ## 0.16.1 (2023-05-04)
  - updated wrong organen labels
 ## 0.16.0 (2023-04-24)

--- a/config/migrations/2023/20230310062435-sync-op/20230402162437-flush-erediensten-before-sync-with-op.sparql
+++ b/config/migrations/2023/20230310062435-sync-op/20230402162437-flush-erediensten-before-sync-with-op.sparql
@@ -134,7 +134,7 @@ WHERE {
     <http://data.lblod.info/vocabularies/erediensten/BestuurVanDeEredienst>
     <http://data.lblod.info/vocabularies/erediensten/RepresentatiefOrgaan>
     <http://data.lblod.info/vocabularies/erediensten/CentraalBestuurVanDeEredienst>
-    <https://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>
+    <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>
     <http://data.lblod.info/vocabularies/erediensten/PositieBedienaar>
   }
   GRAPH <http://mu.semte.ch/graphs/public> {

--- a/config/migrations/2023/20230512115230-sync-op/20230512115230-flush-erediensten-before-sync-with-op.sparql
+++ b/config/migrations/2023/20230512115230-sync-op/20230512115230-flush-erediensten-before-sync-with-op.sparql
@@ -1,0 +1,162 @@
+# removes GestructureerdeIdentificator
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?s ?p ?o.
+  }
+}
+WHERE {
+  VALUES ?typeOfInterest {
+    <http://data.lblod.info/vocabularies/erediensten/BestuurVanDeEredienst>
+    <http://data.lblod.info/vocabularies/erediensten/RepresentatiefOrgaan>
+    <http://data.lblod.info/vocabularies/erediensten/CentraalBestuurVanDeEredienst>
+  }
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?s a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+      ?p ?o.
+
+    ?id <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator> ?s;
+      a <http://www.w3.org/ns/adms#Identifier>.
+
+    ?bestuurseenheid <http://www.w3.org/ns/adms#identifier> ?id;
+      a ?typeOfInterest.
+  }
+}
+
+;
+
+# removes identifiers of interest
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?s ?p ?o.
+  }
+}
+WHERE {
+  VALUES ?typeOfInterest {
+    <http://data.lblod.info/vocabularies/erediensten/BestuurVanDeEredienst>
+    <http://data.lblod.info/vocabularies/erediensten/RepresentatiefOrgaan>
+    <http://data.lblod.info/vocabularies/erediensten/CentraalBestuurVanDeEredienst>
+  }
+  GRAPH <http://mu.semte.ch/graphs/public> {
+
+    ?s a <http://www.w3.org/ns/adms#Identifier>;
+      ?p ?o.
+
+    ?bestuurseenheid <http://www.w3.org/ns/adms#identifier> ?s;
+      a ?typeOfInterest.
+  }
+}
+
+;
+
+# remove mandates
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?s ?p ?o.
+  }
+}
+WHERE {
+  VALUES ?typeOfInterest {
+    <http://data.lblod.info/vocabularies/erediensten/BestuurVanDeEredienst>
+    <http://data.lblod.info/vocabularies/erediensten/RepresentatiefOrgaan>
+    <http://data.lblod.info/vocabularies/erediensten/CentraalBestuurVanDeEredienst>
+  }
+  GRAPH <http://mu.semte.ch/graphs/public> {
+
+    ?s a <http://data.vlaanderen.be/ns/mandaat#Mandaat>;
+      ?p ?o.
+
+    ?bot a <http://data.vlaanderen.be/ns/besluit#Bestuursorgaan>;
+      <http://www.w3.org/ns/org#hasPost> ?s;
+      <http://data.vlaanderen.be/ns/mandaat#isTijdspecialisatieVan> ?orgaan.
+
+    ?orgaan a <http://data.vlaanderen.be/ns/besluit#Bestuursorgaan>;
+      <http://data.vlaanderen.be/ns/besluit#bestuurt> ?eenheid.
+    ?eenheid a ?typeOfInterest.
+  }
+}
+
+;
+
+# bestuursorganen in tijd
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?s ?p ?o.
+  }
+}
+WHERE {
+  VALUES ?typeOfInterest {
+    <http://data.lblod.info/vocabularies/erediensten/BestuurVanDeEredienst>
+    <http://data.lblod.info/vocabularies/erediensten/RepresentatiefOrgaan>
+    <http://data.lblod.info/vocabularies/erediensten/CentraalBestuurVanDeEredienst>
+  }
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?s a <http://data.vlaanderen.be/ns/besluit#Bestuursorgaan>;
+      ?p ?o;
+      <http://data.vlaanderen.be/ns/mandaat#isTijdspecialisatieVan> ?orgaan.
+    ?orgaan a <http://data.vlaanderen.be/ns/besluit#Bestuursorgaan>;
+      <http://data.vlaanderen.be/ns/besluit#bestuurt> ?eenheid.
+    ?eenheid a ?typeOfInterest.
+  }
+}
+
+;
+
+# bestuursorganen
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?s ?p ?o.
+  }
+}
+WHERE {
+  VALUES ?typeOfInterest {
+    <http://data.lblod.info/vocabularies/erediensten/BestuurVanDeEredienst>
+    <http://data.lblod.info/vocabularies/erediensten/RepresentatiefOrgaan>
+    <http://data.lblod.info/vocabularies/erediensten/CentraalBestuurVanDeEredienst>
+  }
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?s a <http://data.vlaanderen.be/ns/besluit#Bestuursorgaan>;
+      ?p ?o;
+      <http://data.vlaanderen.be/ns/besluit#bestuurt> ?eenheid.
+    ?eenheid a ?typeOfInterest.
+  }
+}
+
+;
+
+# remaining
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?s ?p ?o.
+  }
+}
+WHERE {
+  VALUES ?type {
+    <http://data.lblod.info/vocabularies/erediensten/BestuurVanDeEredienst>
+    <http://data.lblod.info/vocabularies/erediensten/RepresentatiefOrgaan>
+    <http://data.lblod.info/vocabularies/erediensten/CentraalBestuurVanDeEredienst>
+    <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>
+    <http://data.lblod.info/vocabularies/erediensten/PositieBedienaar>
+  }
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?s a ?type;
+      ?p ?o.
+  }
+}
+
+;
+
+# betrokken lokaal bestuur
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?s <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> ?o.
+  }
+}
+WHERE {
+  VALUES ?type {
+    <http://data.vlaanderen.be/ns/besluit#Bestuurseenheid>
+  }
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?s a ?type;
+      <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> ?o.
+  }
+}


### PR DESCRIPTION
# Description

During setup of the delta-sync with OP, we needed to first flush the existing data.
Turns out the migration had an issue with betrokken lokale besturen, https vs http error. So these didn't flush properly.
This PR makes a new migration flush everything again.

# Type of change

    [x] Bug fix (non-breaking change which fixes an issue)
    [] New feature (non-breaking change which adds functionality)
    [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
    [] Other

# Related services

N/A

# How to test

1. Find a bettrokken bestuur that hat wrong data. If you synced with QA/PROD the following should work
```sparql
SELECT DISTINCT ?s ?p ?o WHERE { 
  BIND(<http://data.lblod.info/id/betrokkenLokaleBesturen/ba6dfc9d016aa8e82252323898cd2cd0> as ?s)
   ?s ?p ?o.
}
```
should see
```
http://data.lblod.info/id/betrokkenLokaleBesturen/ba6dfc9d016aa8e82252323898cd2cd0 | http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid | http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1
-- | -- | --
http://data.lblod.info/id/betrokkenLokaleBesturen/ba6dfc9d016aa8e82252323898cd2cd0 | http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid | http://lblod.data.gift/concepts/86fcbbbff764f1cba4c7e10dbbae578e
```

We expect only

```
http://data.lblod.info/id/betrokkenLokaleBesturen/ba6dfc9d016aa8e82252323898cd2cd0 | http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid | http://lblod.data.gift/concepts/86fcbbbff764f1cba4c7e10dbbae578e
-- | -- | --
```

2. Run migrations
3. Follow the steps in the readme to do a full sync.
4. Check the results again

Note : Tested :heavy_check_mark: 



# Links to other PR's

N/A
