### PR TITLE
Cleanup data from decisions types

### DIFF
--- a/config/migrations/2023/20231106111659-cleanup-decisions-types.sparql
+++ b/config/migrations/2023/20231106111659-cleanup-decisions-types.sparql
@@ -1,0 +1,69 @@
+PREFIX BesluitType:                      <https://data.vlaanderen.be/id/concept/BesluitType/>
+PREFIX BesluitDocumentType:              <https://data.vlaanderen.be/id/concept/BesluitDocumentType/>
+PREFIX skos:                             <http://www.w3.org/2004/02/skos/core#>
+PREFIX xsd:                              <http://www.w3.org/2001/XMLSchema#>
+PREFIX besluit:                          <http://lblod.data.gift/vocabularies/besluit/>
+PREFIX BestuurseenheidClassificatieCode: <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/>
+PREFIX lblodRule:                        <http://data.lblod.info/id/notification-rule/>
+
+# Delete duplicate obligationToReport Booleans
+DELETE {
+    GRAPH ?g {
+        lblodRule:1f21f0df-4956-4665-9889-f2f1ea1824be besluit:obligationToReport "0"^^xsd:boolean .
+    }
+} 
+WHERE {
+    GRAPH ?g {
+        lblodRule:1f21f0df-4956-4665-9889-f2f1ea1824be besluit:obligationToReport "0"^^xsd:boolean .
+    }
+}
+
+;
+
+# Delete the decidableBy "Autonoom gemeentebedrijf" from lblodRule which has obligationToReport equal to false
+DELETE {
+    GRAPH ?g {
+        lblodRule:7fde1283-f580-4452-a5c4-f2234990d6e9 besluit:decidableBy BestuurseenheidClassificatieCode:36a82ba0-7ff1-4697-a9dd-2e94df73b721 .
+    }
+}
+WHERE {
+    GRAPH ?g {
+        lblodRule:7fde1283-f580-4452-a5c4-f2234990d6e9 besluit:decidableBy BestuurseenheidClassificatieCode:36a82ba0-7ff1-4697-a9dd-2e94df73b721 .
+    }
+}
+
+;
+
+# Delete the NotificationRule from besluitType Budget
+DELETE {
+    GRAPH ?g {
+    BesluitType:40831a2c-771d-4b41-9720-0399998f1873 besluit:notificationRule ?rule.
+
+    ?rule ?p ?o .
+    }
+}
+WHERE {
+    GRAPH ?g {
+    BIND (lblodRule:13077265-a463-4690-b5f9-26729f2369d3 AS ?rule)
+    BesluitType:40831a2c-771d-4b41-9720-0399998f1873 besluit:notificationRule ?rule.
+    ?rule ?p ?o .
+    }
+}
+
+;
+
+# Delete duplicate prefLabel
+DELETE {
+    GRAPH ?g {
+        BesluitDocumentType:18833df2-8c9e-4edd-87fd-b5c252337349 skos:prefLabel "Budgetten(wijzigingen) van besturen van de eredienst" .
+    }
+}
+WHERE {
+    GRAPH ?g {
+        BesluitDocumentType:18833df2-8c9e-4edd-87fd-b5c252337349 skos:prefLabel "Budgetten(wijzigingen) van besturen van de eredienst" .
+    }
+}
+
+
+
+


### PR DESCRIPTION
# Description
DL-5471

This PR fixes data issues for besluitType, besluitDocumentType and also lblodRules.
This is removing triples that were modified or removed in the latest Decisions-Types.ttl from #42 

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

# Related services

- mu-migrations

# How to test 

1. Before running the migration, check on master if the data issue is affecting the data from the migration
2. Run the migration + log the service
3. Check if the data matches with current Decisions-Types.ttl file
4. Any duplicate or unwanted value should be removed.

# What to check

- Any data that is incorrect (shouldn't be the case now but better double check)

# Links to other PR's

- N/A

# Notes

drc restart migrations resource cache