### PR TITLE
Adding new codelists for "besluit over budget wijziging eredienstbestuur"

### DIFF
--- a/config/migrations/2023/20231114145138-add-new-codelists-inhoud-besluit-over-budget-wijziging.sparql
+++ b/config/migrations/2023/20231114145138-add-new-codelists-inhoud-besluit-over-budget-wijziging.sparql
@@ -1,0 +1,37 @@
+INSERT DATA {
+
+GRAPH <http://mu.semte.ch/graphs/public> {
+
+<http://lblod.data.gift/concept-schemes/7856206c-dfda-4163-8bd3-f465c794eced> a <http://www.w3.org/2004/02/skos/core#ConceptScheme> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "7856206c-dfda-4163-8bd3-f465c794eced" ;
+    <http://www.w3.org/2004/02/skos/core#prefLabel> "Type inhoud van het besluit (erediensten)"@nl, "Type of content of decision"@en ;
+    <http://www.w3.org/2004/02/skos/core#definition> "Inhoud bij inzendingen van het besluit over-budget(wijziging)" .
+
+<https://data.vlaanderen.be/id/concept/BesluitType/2ee9e3fa-88f0-40f8-a545-bb4cfef2b06d> a <http://www.w3.org/2004/02/skos/core#Concept>,
+    <http://www.w3.org/2000/01/rdf-schema#Class> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "2ee9e3fa-88f0-40f8-a545-bb4cfef2b06d" ;
+    <http://www.w3.org/2004/02/skos/core#prefLabel> "Akteneming"@nl ;
+    <http://www.w3.org/2004/02/skos/core#inScheme> <https://data.vlaanderen.be/id/conceptscheme/BesluitType> ;
+    <http://www.w3.org/2004/02/skos/core#topConceptOf> <https://data.vlaanderen.be/id/conceptscheme/BesluitType> ;
+    <http://www.w3.org/2004/02/skos/core#inScheme> <http://lblod.data.gift/concept-schemes/7856206c-dfda-4163-8bd3-f465c794eced> ;
+    <http://www.w3.org/2004/02/skos/core#topConceptOf> <http://lblod.data.gift/concept-schemes/7856206c-dfda-4163-8bd3-f465c794eced> .
+
+<https://data.vlaanderen.be/id/concept/BesluitType/d3cfbe2c-0777-40b6-9e12-781239a68b0a> a <http://www.w3.org/2004/02/skos/core#Concept>,
+    <http://www.w3.org/2000/01/rdf-schema#Class> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "d3cfbe2c-0777-40b6-9e12-781239a68b0a" ;
+    <http://www.w3.org/2004/02/skos/core#prefLabel> "Aanpassingsbesluit"@nl ;
+    <http://www.w3.org/2004/02/skos/core#inScheme> <https://data.vlaanderen.be/id/conceptscheme/BesluitType> ;
+    <http://www.w3.org/2004/02/skos/core#topConceptOf> <https://data.vlaanderen.be/id/conceptscheme/BesluitType> ;
+    <http://www.w3.org/2004/02/skos/core#inScheme> <http://lblod.data.gift/concept-schemes/7856206c-dfda-4163-8bd3-f465c794eced> ;
+    <http://www.w3.org/2004/02/skos/core#topConceptOf> <http://lblod.data.gift/concept-schemes/7856206c-dfda-4163-8bd3-f465c794eced> .
+
+<https://data.vlaanderen.be/id/concept/BesluitType/027ac432-d2e0-4421-a22d-7431980b38d8> a <http://www.w3.org/2004/02/skos/core#Concept>,
+    <http://www.w3.org/2000/01/rdf-schema#Class> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "027ac432-d2e0-4421-a22d-7431980b38d8" ;
+    <http://www.w3.org/2004/02/skos/core#prefLabel> "Goedkeuringsbesluit"@nl ;
+    <http://www.w3.org/2004/02/skos/core#inScheme> <https://data.vlaanderen.be/id/conceptscheme/BesluitType> ;
+    <http://www.w3.org/2004/02/skos/core#topConceptOf> <https://data.vlaanderen.be/id/conceptscheme/BesluitType> ;
+    <http://www.w3.org/2004/02/skos/core#inScheme> <http://lblod.data.gift/concept-schemes/7856206c-dfda-4163-8bd3-f465c794eced> ;
+    <http://www.w3.org/2004/02/skos/core#topConceptOf> <http://lblod.data.gift/concept-schemes/7856206c-dfda-4163-8bd3-f465c794eced> .
+  }
+}


### PR DESCRIPTION
# Description

DL-5483

This PR adds new concepts to the "Besluit over budget wijziging eredienstbestuur".

This codelist is giving three options to choose from : Akteneming, Aanpassingsbesluit and Goedkeuringsbesluit

- Adding migrations to create new codelists

**Note : This PR needs to be merged with the form adjustement from "Links to other PR's" Section**

# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

# Related services

- enrich-submission
- mu-migrations

# How to test 

- N/A

# What to check

- N/A

# Links to other PR's

- https://github.com/lblod/app-digitaal-loket/pull/478
- https://github.com/lblod/app-meldingsplichtige-api/pull/36
- https://github.com/lblod/app-toezicht-abb/pull/34
- https://github.com/lblod/app-public-decisions-database/pull/20
- https://github.com/lblod/app-worship-decisions-database/pull/49
- https://github.com/lblod/manage-submission-form-tooling/pull/39
- https://github.com/lblod/enrich-submission-service/pull/15

# Notes

drc restart migrations resource cache