### PR TITLE
Replace https by http in lblodlg prefix

### DIFF
--- a/config/op-consumer/public/delta-context-config.js
+++ b/config/op-consumer/public/delta-context-config.js
@@ -12,7 +12,7 @@ PREFIX euvoc: <http://publications.europa.eu/ontology/euvoc#>
 PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
 PREFIX foaf: <http://xmlns.com/foaf/0.1/>
 PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
-PREFIX lblodlg: <https://data.lblod.info/vocabularies/leidinggevenden/>
+PREFIX lblodlg: <http://data.lblod.info/vocabularies/leidinggevenden/>
 PREFIX locn: <http://www.w3.org/ns/locn#>
 PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
 PREFIX mu: <http://mu.semte.ch/vocabularies/core/>


### PR DESCRIPTION
This prefix has wrongly been defined with https instead of http in some places. Luckily, it has no impact on the data because everywhere where it has been defined that way, it also never has been used. So here we just rectify the (unused) prefixes to avoid bringing further confusion.