### PR TITLE
Add missing logging and restart configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 # Changelog
+## Unreleased
+- Bundle new forms and their rules (DL-5671)
+- Add missing restart and logging configs to a couple of services (DL-5818)
+### Deploy Notes
+#### Docker Commands
+- `drc up -d resource-labels migrations delta-report-generator leidinggevenden-consumer`
+- `drc restart migrations`
+- `drc restart resource cache`
 ## 0.21.0 (2024-03-07)
 - Update the frontend to `v0.3.0` & `v0.3.1`: https://github.com/lblod/frontend-centrale-vindplaats/blob/master/CHANGELOG.md#v031-2024-02-21 (DL-5658)
 - Add `gn-publications-consumer` to consume `Gelink-Notuleren` publications (DL-5659)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       - virtuoso:database
     labels:
       - "logging=true"
+    logging: *default-logging
   identifier:
     image: semtech/mu-identifier:1.10.1
     environment:
@@ -63,6 +64,7 @@ services:
     restart: always
     labels:
       - "logging=true"
+    logging: *default-logging
   cache:
     image: semtech/mu-cache:2.0.1
     links:
@@ -125,6 +127,8 @@ services:
       OUTBOX: "http://data.lblod.info/id/mail-folders/2"
     volumes:
       - ./config/delta-consumer/report-generator:/config
+    restart: always
+    logging: *default-logging
   mandatendatabank-consumer:
       image: lblod/delta-consumer:0.0.24
       environment:
@@ -166,6 +170,7 @@ services:
     restart: always
     labels:
       - "logging=true"
+    logging: *default-logging
   gn-publications-consumer:
     image: lblod/delta-consumer:0.0.24
     environment:


### PR DESCRIPTION
## Ticket Number

DL-5818

## Ticket Description

This repo was missing some `logging:` and `restart:` configurations for some of its services.