### PR TITLE
Remove laguaged tagged labels from the database

### DIFF
--- a/config/migrations/2024/20240507163340-fix-labels.sparql
+++ b/config/migrations/2024/20240507163340-fix-labels.sparql
@@ -1,0 +1,68 @@
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+INSERT DATA {
+  GRAPH <http://semte.ch/graph/temp/79b491b5-02ce-449e-9f75-7c679cdec1b8> {
+    <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/6d4cf4dd-2080-4752-8733-d02a036b2df0>	<http://www.w3.org/2004/02/skos/core#prefLabel>	"Financieel directeur" .
+    <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e000011>	<http://www.w3.org/2004/02/skos/core#prefLabel>	"Gemeenteraadslid" .
+    <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e000022>	<http://www.w3.org/2004/02/skos/core#prefLabel>	"Lid van het districtscollege" .
+    <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e00001d>	<http://www.w3.org/2004/02/skos/core#prefLabel>	"Districtsburgemeester" .
+    <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/3200ffc1-bb72-4235-a81c-64aa578b0789>	<http://www.w3.org/2004/02/skos/core#prefLabel>	"Adjunct Financieel Directeur" .
+    <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e000016>	<http://www.w3.org/2004/02/skos/core#prefLabel>	"Voorzitter van de Raad voor Maatschappelijk Welzijn" .
+    <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e000017>	<http://www.w3.org/2004/02/skos/core#prefLabel>	"Lid van het Vast Bureau" .
+    <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e000020>	<http://www.w3.org/2004/02/skos/core#prefLabel>	"Gedeputeerde" .
+    <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/59a90e03-4f22-4bb9-8c91-132618db4b38>	<http://www.w3.org/2004/02/skos/core#prefLabel>	"Toegevoegde schepen" .
+    <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e000014>	<http://www.w3.org/2004/02/skos/core#prefLabel>	"Schepen" .
+    <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e000018>	<http://www.w3.org/2004/02/skos/core#prefLabel>	"Voorzitter van het Vast bureau" .
+    <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/932a0598-8f05-480e-abda-229365e99610>	<http://www.w3.org/2004/02/skos/core#prefLabel>	"Algemeen directeur-co\u00F6rdinator" .
+    <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/789f263f-f789-4628-a541-b14fd9d38278>	<http://www.w3.org/2004/02/skos/core#prefLabel>	"Gemeentesecretaris" .
+    <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e000026>	<http://www.w3.org/2004/02/skos/core#prefLabel>	"Voorzitter van het districtscollege" .
+    <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/63195ec6-02cb-4f86-ac8e-29c5183a11dc>	<http://www.w3.org/2004/02/skos/core#prefLabel>	"Griffier" .
+    <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e000012>	<http://www.w3.org/2004/02/skos/core#prefLabel>	"Voorzitter van de gemeenteraad" .
+    <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/1c9ea819-f7c3-4ff6-9e2c-8f83ada5794a>	<http://www.w3.org/2004/02/skos/core#prefLabel>	"Financieel beheerder van het OCMW" .
+    <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e000019>	<http://www.w3.org/2004/02/skos/core#prefLabel>	"Lid van het Bijzonder Comit\u00E9 voor de Sociale Dienst" .
+    <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e00001e>	<http://www.w3.org/2004/02/skos/core#prefLabel>	"Districtsschepen" .
+    <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/b213c870-c762-4e39-9f78-3abdeda4b64a>	<http://www.w3.org/2004/02/skos/core#prefLabel>	"Financieel beheerder" .
+    <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e000023>	<http://www.w3.org/2004/02/skos/core#prefLabel>	"Ocmw-ondervoorzitter" .
+    <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/d7c00cd1-baf1-4346-83c0-6796c0bedd84>	<http://www.w3.org/2004/02/skos/core#prefLabel>	"Financieel directeur-co\u00F6rdinator" .
+    <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/d7c00cd1-baf1-4346-83c0-6796c0bedd85>	<http://www.w3.org/2004/02/skos/core#prefLabel>	"Gouverneur" .
+    <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/39e08271-68db-4282-897f-5cba88c71862>	<http://www.w3.org/2004/02/skos/core#prefLabel>	"Algemeen directeur" .
+    <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e00001f>	<http://www.w3.org/2004/02/skos/core#prefLabel>	"Provincieraadslid" .
+    <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e00001a>	<http://www.w3.org/2004/02/skos/core#prefLabel>	"Voorzitter van het Bijzonder Comit\u00E9 voor de Sociale Dienst" .
+    <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/7b038cc40bba10bec833ecfe6f15bc7a>	<http://www.w3.org/2004/02/skos/core#prefLabel>	"Aangewezen burgemeester" .
+    <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/b6eaf1d4-d9b4-409d-a137-af801cf96c67>	<http://www.w3.org/2004/02/skos/core#prefLabel>	"OCMW-secretaris" .
+    <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e000015>	<http://www.w3.org/2004/02/skos/core#prefLabel>	"Lid van de Raad voor Maatschappelijk Welzijn" .
+    <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e000013>	<http://www.w3.org/2004/02/skos/core#prefLabel>	"Burgemeester" .
+    <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/f7b4e17b-6f4e-48e7-a558-bce61669f59a>	<http://www.w3.org/2004/02/skos/core#prefLabel>	"Adjunct Algemeen Directeur" .
+    <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e00001c>	<http://www.w3.org/2004/02/skos/core#prefLabel>	"Voorzitter van de districtsraad" .
+    <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e00001b>	<http://www.w3.org/2004/02/skos/core#prefLabel>	"Districtsraadslid" .
+    <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/855489b9-b584-4f34-90b2-39aea808cd9f>	<http://www.w3.org/2004/02/skos/core#prefLabel>	"Leidend ambtenaar" .
+    <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e000027>	<http://www.w3.org/2004/02/skos/core#prefLabel>	"Voorzitter van de provincieraad" .
+  }
+}
+
+;
+
+DELETE {
+  GRAPH ?g {
+    ?s skos:prefLabel ?label.
+  }
+}
+INSERT {
+  GRAPH ?g {
+    ?s skos:prefLabel ?newLabel.
+  }
+}
+WHERE {
+
+  GRAPH <http://semte.ch/graph/temp/79b491b5-02ce-449e-9f75-7c679cdec1b8> {
+    ?s skos:prefLabel ?newLabel.
+  }
+
+  GRAPH ?g {
+    ?s skos:prefLabel ?label.
+  }
+}
+
+;
+
+CLEAR GRAPH <http://semte.ch/graph/temp/79b491b5-02ce-449e-9f75-7c679cdec1b8>


### PR DESCRIPTION
Ref. DL-5889

Cleans up broken labels. They were ingested by scraped data from GN. Root cause will be tackled.