### PR TITLE
Chore/add db cleanup service and fallback fix for potential double labels coming from besluiten

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## 0.23.0
 - Re-init op-public-consumer with new consumer (DL-6102 and also OP-3422)
 - bump other consumers
+- Added cleanup job (DL-6216)
 ### Deploy instructions
 #### Re-init op-public-consumer
 - Note: the application will be down for a while.

--- a/config/migrations/2024/20241023145126-add-job-to-remove-wrong-labels-bestuurseenheid-coming-from-besluiten.graph
+++ b/config/migrations/2024/20241023145126-add-job-to-remove-wrong-labels-bestuurseenheid-coming-from-besluiten.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/public

--- a/config/migrations/2024/20241023145126-add-job-to-remove-wrong-labels-bestuurseenheid-coming-from-besluiten.ttl
+++ b/config/migrations/2024/20241023145126-add-job-to-remove-wrong-labels-bestuurseenheid-coming-from-besluiten.ttl
@@ -1,0 +1,39 @@
+@prefix cleanup:  <http://mu.semte.ch/vocabularies/ext/cleanup/> .
+@prefix mu:       <http://mu.semte.ch/vocabularies/core/> .
+@prefix dcterms:  <http://purl.org/dc/terms/> .
+
+<http://data.lblod.info/id/cleanup-job/4a0f6da3-2c71-465d-b075-8d4b43a854d2> a cleanup:Job ;
+  mu:uuid "4a0f6da3-2c71-465d-b075-8d4b43a854d2" ;
+  dcterms:title "Removes wrong skos:prefLabel from besluit:Bestuurseenheid. Sometimes the lblod-harvester from besluit:Besluit ingests too much data." ;
+  cleanup:randomQuery """
+    PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+    DELETE {
+        GRAPH <http://mu.semte.ch/graphs/public> {
+          ?s skos:prefLabel ?label.
+        }
+    }
+    INSERT {
+        GRAPH <http://mu.semte.ch/graphs/public> {
+          ?s skos:prefLabel ?realLabel.
+        }
+    }
+    WHERE {
+
+      GRAPH <http://mu.semte.ch/graphs/public> {
+        ?s a <http://data.vlaanderen.be/ns/besluit#Bestuurseenheid>;
+          skos:prefLabel ?label.
+      }
+
+      FILTER NOT EXISTS {
+          GRAPH <http://mu.semte.ch/graphs/landing-zone/op-public> {
+            ?s skos:prefLabel ?label.
+         }
+      }
+
+      GRAPH <http://mu.semte.ch/graphs/landing-zone/op-public> {
+            ?s skos:prefLabel ?realLabel.
+      }
+    }
+    """ ;
+  cleanup:cronPattern "0 * * * *" .

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -39,3 +39,5 @@ services:
     restart: "no"
   op-public-consumer:
     restart: "no"
+  dbcleanup:
+    restart: "no"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -110,6 +110,12 @@ services:
       - "logging=true"
     restart: always
     logging: *default-logging
+  dbcleanup:
+    image: lblod/db-cleanup-service:0.5.0
+    labels:
+      - "logging=true"
+    restart: always
+    logging: *default-logging
 ################################################################################
 # DELTAS
 ################################################################################


### PR DESCRIPTION
See DL-6216. 

This adds a scheduled cleanup job to remove potentially faulty labels from besluit:Bestuurseenheid. This is introduced as currently the source from `besluit:Besluit` can sometimes inject nasty variations of labels. Eventually this shouldn't come through from the besluiten harvester. But for now we periodically run the clean up services ourselves.

To test
`docker compose exec dbcleanup curl -X GET "http://localhost/runCronjob?cronJobID=4a0f6da3-2c71-465d-b075-8d4b43a854d2`