### PR TITLE
Fix old bestuursorganen label and redundant bestuursorganen leidinggevenden

### DIFF
--- a/config/migrations/2024/20241125124806-flush-duplicate-bestuursorganen.sparql
+++ b/config/migrations/2024/20241125124806-flush-duplicate-bestuursorganen.sparql
@@ -2,7 +2,7 @@ PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
 
 DELETE {
-  GRAPH <http://mu.semte.ch/graphs/public> {
+  GRAPH ?graph {
     ?orgIntijdNew ?orgIntijdNewP  ?orgIntijdNewO.
   }
 }
@@ -17,19 +17,22 @@ WHERE {
     <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab19107-82d2-4273-a986-3da86fda050d> # Griffier
    }
 
-  GRAPH <http://mu.semte.ch/graphs/public> {
+  VALUES ?graph {
+    <http://mu.semte.ch/graphs/public>
+    <http://mu.semte.ch/application>
+  }
 
-    ?s a <http://data.vlaanderen.be/ns/besluit#Bestuursorgaan>;
-      <http://www.w3.org/ns/org#classification> ?class.
+  ?s a <http://data.vlaanderen.be/ns/besluit#Bestuursorgaan>;
+    <http://www.w3.org/ns/org#classification> ?class.
 
-    ?orgIntijdOld generiek:isTijdspecialisatieVan ?s;
-      <http://data.vlaanderen.be/ns/mandaat#bindingStart> ?old.
+  ?orgIntijdOld generiek:isTijdspecialisatieVan ?s;
+    <http://data.vlaanderen.be/ns/mandaat#bindingStart> ?old.
 
-    ?orgIntijdNew generiek:isTijdspecialisatieVan ?s;
-      <http://data.vlaanderen.be/ns/mandaat#bindingStart> ?new.
+  ?orgIntijdNew generiek:isTijdspecialisatieVan ?s;
+    <http://data.vlaanderen.be/ns/mandaat#bindingStart> ?new.
 
   FILTER(?new > ?old)
 
-    ?orgIntijdNew ?orgIntijdNewP ?orgIntijdNewO.
-  }
+  ?orgIntijdNew ?orgIntijdNewP ?orgIntijdNewO.
+
 }

--- a/config/migrations/2024/20241125124806-flush-duplicate-bestuursorganen.sparql
+++ b/config/migrations/2024/20241125124806-flush-duplicate-bestuursorganen.sparql
@@ -1,0 +1,35 @@
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?orgIntijdNew ?orgIntijdNewP  ?orgIntijdNewO.
+  }
+}
+WHERE {
+  VALUES ?class {
+    <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/11f0af9e-016c-4e0b-983a-d8bc73804abc> # "Adjunct-algemeen directeur"
+    <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/39854196-f214-4688-87a1-d6ad12baa2fa> # "Algemeen directeur"
+    <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4> # "Leidend Ambtenaar"
+    <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/62644b9c-4514-41dd-a660-4c35257f2b35> # "Financieel directeu"
+    <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/ed40469e-3b6f-4f38-99ba-18912ee352b0> # "Adjunct-financieel directeur"
+    <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/3e9f22c1-0d35-445b-8a37-494addedf2d8> # "Financieel beheerder"
+    <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab19107-82d2-4273-a986-3da86fda050d> # Griffier
+   }
+
+  GRAPH <http://mu.semte.ch/graphs/public> {
+
+    ?s a <http://data.vlaanderen.be/ns/besluit#Bestuursorgaan>;
+      <http://www.w3.org/ns/org#classification> ?class.
+
+    ?orgIntijdOld generiek:isTijdspecialisatieVan ?s;
+      <http://data.vlaanderen.be/ns/mandaat#bindingStart> ?old.
+
+    ?orgIntijdNew generiek:isTijdspecialisatieVan ?s;
+      <http://data.vlaanderen.be/ns/mandaat#bindingStart> ?new.
+
+  FILTER(?new > ?old)
+
+    ?orgIntijdNew ?orgIntijdNewP ?orgIntijdNewO.
+  }
+}

--- a/config/migrations/2024/re-init-op-public-consumer/20241125100721-fix-bestuursorganen-labels.sparql
+++ b/config/migrations/2024/re-init-op-public-consumer/20241125100721-fix-bestuursorganen-labels.sparql
@@ -1,0 +1,36 @@
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX org: <http://www.w3.org/ns/org#>
+
+DELETE {
+   GRAPH <http://mu.semte.ch/graphs/public> {
+     ?s <http://www.w3.org/2004/02/skos/core#prefLabel> ?label.
+  }
+} WHERE {
+   GRAPH <http://mu.semte.ch/graphs/public> {
+     ?s a <http://data.vlaanderen.be/ns/besluit#Bestuursorgaan>;
+       <http://www.w3.org/2004/02/skos/core#prefLabel> ?label.
+  }
+}
+
+;
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?bestuursorgaan skos:prefLabel ?bestuursorgaanLabel.
+  }
+}
+WHERE {
+
+  GRAPH <http://mu.semte.ch/graphs/landing-zone/op-public> {
+    ?bestuursorgaan
+      besluit:bestuurt ?bestuurseenheid;
+      org:classification ?classificatie.
+
+    ?classificatie
+      skos:prefLabel ?classificatieLabel.
+    ?bestuurseenheid
+      skos:prefLabel ?bestuurseenheidLabel.
+  }
+  BIND(CONCAT(str(?classificatieLabel), " ", str(?bestuurseenheidLabel)) as ?bestuursorgaanLabel)
+}


### PR DESCRIPTION
During cutover, we forgot to flush the old bestuursorganenlabel. This migration fixes this. Flushes the old ones and adds the one constructed by the consumer.