### PR TITLE
Import registered organizations classification codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,33 @@
 # Changelog
+## Unreleased
+ - Import classification codes `ext:GeregistreerdeOrganisatieClassificatieCode` from OP [OP-3470]
+### Deploy instructions
+#### Re-init op-public-consumer
+- Ensure backup (check crontab to get the command the create one)
+- Ensure in `docker-compose.override.yml` (on prod)
+  ```
+   op-public-consumer:
+    environment:
+      DCR_SYNC_BASE_URL: "https://organisaties.abb.vlaanderen.be"
+      DCR_DISABLE_INITIAL_SYNC: "false"
+      DCR_DISABLE_DELTA_INGEST: "false"
+      DCR_LANDING_ZONE_DATABASE: "virtuoso" # for the initial sync, we go directly to virtuoso
+      DCR_REMAPPING_DATABASE: "virtuoso" # for the initial sync, we go directly to virtuoso
+  ```
+- Remove previous initial sync job and re-trigger initial sync
+  ```
+  drc exec op-public-consumer curl -X DELETE http://localhost/initial-sync-jobs
+  drc exec op-public-consumer curl -X POST http://localhost/initial-sync-jobs
+  ```
+- Wait until the consumer is finished. (If you see failing on the last step, the mapping, boost the virtuoso config)
+- Ensure op-public-consumer in `docker-compose.override.yml` is syncing with database again. The final `docker-compose.override.yml` will look like
+  ```
+   op-public-consumer:
+    environment:
+      DCR_SYNC_BASE_URL: "https://organisaties.abb.vlaanderen.be"
+      DCR_DISABLE_INITIAL_SYNC: "false"
+      DCR_DISABLE_DELTA_INGEST: "false"
+  ```
 ## 0.24.3 (2024-12-11)
  - Add OCMW to notification rule of samenstelling bestuursorganen [DL-6344]
 ## 0.24.2 (2024-11-28)

--- a/config/delta-consumer/op-public-consumer/mapping/queries/op2dl/pass/pass-all-properties-part-1.sparql
+++ b/config/delta-consumer/op-public-consumer/mapping/queries/op2dl/pass/pass-all-properties-part-1.sparql
@@ -27,5 +27,6 @@ WHERE {
     <http://lblod.data.gift/vocabularies/organisatie/TypeVestiging>
     <http://data.vlaanderen.be/ns/mandaat#Mandaat>
     <http://data.lblod.info/vocabularies/leidinggevenden/Bestuursfunctie>
+    <http://mu.semte.ch/vocabularies/ext/GeregistreerdeOrganisatieClassificatieCode>
   }
 }


### PR DESCRIPTION
# Context

OP-3470

New classification codes of type `ext:GeregistreerdeOrganisatieClassificatieCode` have been added in OP to reflect the classification of associations, that are not exactly administrative units. In this PR, I modify the configuration of the OP public consumer to ingest them.

# Test instructions

To test it (and also when deploying) we have to re-trigger an initial sync of the op consumer.

**NOTE**: I don't think that we need to entirely flush the op public consumer because CVP isn't updating any data so we are just going to ingest existing data exactly the same way as they already are in the app. If you disagree please tell me! 

1. Add the following to your `docker-compose.override.yml`
```
  op-public-consumer:
    environment:
      DCR_SYNC_BASE_URL: "https://dev.organisaties.abb.lblod.info"
      DCR_DISABLE_INITIAL_SYNC: "false"
      DCR_DISABLE_DELTA_INGEST: "false"
      DCR_LANDING_ZONE_DATABASE: "virtuoso" # for the initial sync, we go directly to virtuoso
      DCR_REMAPPING_DATABASE: "virtuoso" # for the initial sync, we go directly to virtuoso
```

2. Re trigger the op public consumer initial sync
```
drc exec op-public-consumer curl -X DELETE http://localhost/initial-sync-jobs
drc exec op-public-consumer curl -X POST http://localhost/initial-sync-jobs
```

3. Check that triples of type `ext:GeregistreerdeOrganisatieClassificatieCode` are now available in CVP