### PR TITLE
Hotfix/switch to mdb to op master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 # Changelog
+## Unreleased
+- Prepare application to accept data from OP as master (and not leidinggevenden or mandatarissen from loket)
+### deploy notes
+```
+drc up -d op-public-consumer
+drc restart migrations
+```
 ## 0.24.7 (2025-02-07)
 - Update form 'Reglementen en verordeningen' lblodRule [DL-6357]
 ### Deploy instructions

--- a/config/delta-consumer/op-public-consumer/mapping/queries/op2dl/mapping/bestuurseenheid-classificatie-code.sparql
+++ b/config/delta-consumer/op-public-consumer/mapping/queries/op2dl/mapping/bestuurseenheid-classificatie-code.sparql
@@ -1,0 +1,9 @@
+INSERT {
+ ?s a <http://lblod.data.gift/vocabularies/organisatie/BestuurseenheidClassificatieCode>,
+    <http://mu.semte.ch/vocabularies/ext/OrganizationClassificationCode>,
+    <http://mu.semte.ch/vocabularies/ext/BestuurseenheidClassificatieCode>,
+    <http://www.w3.org/2004/02/skos/core#Concept>
+
+} WHERE {
+  ?s a <http://lblod.data.gift/vocabularies/organisatie/BestuurseenheidClassificatieCode>
+}

--- a/config/delta-consumer/op-public-consumer/mapping/queries/op2dl/mapping/bestuurseenheid-classificatie-code.sparql
+++ b/config/delta-consumer/op-public-consumer/mapping/queries/op2dl/mapping/bestuurseenheid-classificatie-code.sparql
@@ -1,4 +1,4 @@
-INSERT {
+CONSTRUCT {
  ?s a <http://lblod.data.gift/vocabularies/organisatie/BestuurseenheidClassificatieCode>,
     <http://mu.semte.ch/vocabularies/ext/OrganizationClassificationCode>,
     <http://mu.semte.ch/vocabularies/ext/BestuurseenheidClassificatieCode>,

--- a/config/delta-consumer/op-public-consumer/mapping/queries/op2dl/mapping/bestuursfunctie-code.sparql
+++ b/config/delta-consumer/op-public-consumer/mapping/queries/op2dl/mapping/bestuursfunctie-code.sparql
@@ -1,0 +1,5 @@
+CONSTRUCT {
+  ?s a <http://mu.semte.ch/vocabularies/ext/BestuursfunctieCode>.
+} WHERE {
+  ?s a <http://lblod.data.gift/vocabularies/organisatie/BestuursfunctieCode>.
+}

--- a/config/delta-consumer/op-public-consumer/mapping/queries/op2dl/mapping/bestuursfunctiecode.sparql
+++ b/config/delta-consumer/op-public-consumer/mapping/queries/op2dl/mapping/bestuursfunctiecode.sparql
@@ -1,0 +1,8 @@
+CONSTRUCT {
+  ?s a <http://lblod.data.gift/vocabularies/organisatie/BestuursfunctieCode>,
+    <http://mu.semte.ch/vocabularies/ext/BestuursfunctieCode>,
+    <http://www.w3.org/2004/02/skos/core#Concept>.
+}
+WHERE {
+  ?s a <http://lblod.data.gift/vocabularies/organisatie/BestuursfunctieCode>.
+}

--- a/config/delta-consumer/op-public-consumer/mapping/queries/op2dl/mapping/bestuursfunctiecode.sparql
+++ b/config/delta-consumer/op-public-consumer/mapping/queries/op2dl/mapping/bestuursfunctiecode.sparql
@@ -1,8 +1,0 @@
-CONSTRUCT {
-  ?s a <http://lblod.data.gift/vocabularies/organisatie/BestuursfunctieCode>,
-    <http://mu.semte.ch/vocabularies/ext/BestuursfunctieCode>,
-    <http://www.w3.org/2004/02/skos/core#Concept>.
-}
-WHERE {
-  ?s a <http://lblod.data.gift/vocabularies/organisatie/BestuursfunctieCode>.
-}

--- a/config/delta-consumer/op-public-consumer/mapping/queries/op2dl/mapping/mandataris-status-code.sparql
+++ b/config/delta-consumer/op-public-consumer/mapping/queries/op2dl/mapping/mandataris-status-code.sparql
@@ -1,4 +1,4 @@
-INSERT {
+CONSTRUCT {
   ?s a <http://mu.semte.ch/vocabularies/ext/MandatarisStatusCode>
 } WHERE {
   ?s a <http://lblod.data.gift/vocabularies/organisatie/MandatarisStatusCode>

--- a/config/delta-consumer/op-public-consumer/mapping/queries/op2dl/mapping/mandataris-status-code.sparql
+++ b/config/delta-consumer/op-public-consumer/mapping/queries/op2dl/mapping/mandataris-status-code.sparql
@@ -1,0 +1,5 @@
+INSERT {
+  ?s a <http://mu.semte.ch/vocabularies/ext/MandatarisStatusCode>
+} WHERE {
+  ?s a <http://lblod.data.gift/vocabularies/organisatie/MandatarisStatusCode>
+}

--- a/config/delta-consumer/op-public-consumer/mapping/queries/op2dl/pass/pass-all-properties-part-1.sparql
+++ b/config/delta-consumer/op-public-consumer/mapping/queries/op2dl/pass/pass-all-properties-part-1.sparql
@@ -31,5 +31,6 @@ WHERE {
     <http://lblod.data.gift/vocabularies/organisatie/BestuursfunctieCode>
     <http://data.lblod.info/vocabularies/leidinggevenden/FunctionarisStatusCode>
     <http://lblod.data.gift/vocabularies/organisatie/MandatarisStatusCode>
+    <http://www.w3.org/ns/prov#Location>
   }
 }

--- a/config/delta-consumer/op-public-consumer/mapping/queries/op2dl/pass/pass-all-properties-part-1.sparql
+++ b/config/delta-consumer/op-public-consumer/mapping/queries/op2dl/pass/pass-all-properties-part-1.sparql
@@ -28,5 +28,7 @@ WHERE {
     <http://data.vlaanderen.be/ns/mandaat#Mandaat>
     <http://data.lblod.info/vocabularies/leidinggevenden/Bestuursfunctie>
     <http://mu.semte.ch/vocabularies/ext/GeregistreerdeOrganisatieClassificatieCode>
+    <http://lblod.data.gift/vocabularies/organisatie/BestuursfunctieCode>
+    <http://data.lblod.info/vocabularies/leidinggevenden/FunctionarisStatusCode>
   }
 }

--- a/config/delta-consumer/op-public-consumer/mapping/queries/op2dl/pass/pass-all-properties-part-1.sparql
+++ b/config/delta-consumer/op-public-consumer/mapping/queries/op2dl/pass/pass-all-properties-part-1.sparql
@@ -30,5 +30,6 @@ WHERE {
     <http://mu.semte.ch/vocabularies/ext/GeregistreerdeOrganisatieClassificatieCode>
     <http://lblod.data.gift/vocabularies/organisatie/BestuursfunctieCode>
     <http://data.lblod.info/vocabularies/leidinggevenden/FunctionarisStatusCode>
+    <http://lblod.data.gift/vocabularies/organisatie/MandatarisStatusCode>
   }
 }

--- a/config/migrations/2025/20250310-make-mdb-to-op-master-switch/20250310122511-bestuursfunctie.sparql
+++ b/config/migrations/2025/20250310-make-mdb-to-op-master-switch/20250310122511-bestuursfunctie.sparql
@@ -1,0 +1,13 @@
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+     ?s a <http://lblod.data.gift/vocabularies/organisatie/BestuursfunctieCode>;
+       ?p ?o.
+  }
+
+}
+WHERE {
+   GRAPH <http://mu.semte.ch/graphs/landing-zone/op-public> {
+     ?s a <http://lblod.data.gift/vocabularies/organisatie/BestuursfunctieCode>;
+       ?p ?o.
+   }
+}

--- a/config/migrations/2025/20250310-make-mdb-to-op-master-switch/20250310122511-bestuursfunctie.sparql
+++ b/config/migrations/2025/20250310-make-mdb-to-op-master-switch/20250310122511-bestuursfunctie.sparql
@@ -1,6 +1,7 @@
 INSERT {
   GRAPH <http://mu.semte.ch/graphs/public> {
-     ?s a <http://lblod.data.gift/vocabularies/organisatie/BestuursfunctieCode>;
+     ?s a <http://lblod.data.gift/vocabularies/organisatie/BestuursfunctieCode>,
+       <http://mu.semte.ch/vocabularies/ext/BestuursfunctieCode>;
        ?p ?o.
   }
 

--- a/config/migrations/2025/20250310-make-mdb-to-op-master-switch/20250310123833-bestuurseenheid-classificatie.sparql
+++ b/config/migrations/2025/20250310-make-mdb-to-op-master-switch/20250310123833-bestuurseenheid-classificatie.sparql
@@ -1,0 +1,14 @@
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?s a <http://lblod.data.gift/vocabularies/organisatie/BestuurseenheidClassificatieCode>,
+      <http://mu.semte.ch/vocabularies/ext/OrganizationClassificationCode>,
+      <http://mu.semte.ch/vocabularies/ext/BestuurseenheidClassificatieCode>,
+      <http://www.w3.org/2004/02/skos/core#Concept>;
+      ?p ?o.
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/landing-zone/op-public> {
+    ?s a <http://lblod.data.gift/vocabularies/organisatie/BestuurseenheidClassificatieCode>;
+      ?p ?o.
+  }
+}

--- a/config/migrations/2025/20250310-make-mdb-to-op-master-switch/20250310145339-mandataris-status-code.sparql
+++ b/config/migrations/2025/20250310-make-mdb-to-op-master-switch/20250310145339-mandataris-status-code.sparql
@@ -1,0 +1,11 @@
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?s a <http://mu.semte.ch/vocabularies/ext/MandatarisStatusCode>;
+      ?p ?o.
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/landing-zone/op-public> {
+    ?s a <http://lblod.data.gift/vocabularies/organisatie/MandatarisStatusCode>;
+      ?p ?o.
+  }
+}

--- a/config/migrations/2025/20250310-make-mdb-to-op-master-switch/20250310145348-functionaris-status-code.sparql
+++ b/config/migrations/2025/20250310-make-mdb-to-op-master-switch/20250310145348-functionaris-status-code.sparql
@@ -1,0 +1,11 @@
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?s a <http://data.lblod.info/vocabularies/leidinggevenden/FunctionarisStatusCode>;
+      ?p ?o.
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/landing-zone/op-public> {
+    ?s a <http://data.lblod.info/vocabularies/leidinggevenden/FunctionarisStatusCode>;
+      ?p ?o.
+  }
+}

--- a/config/migrations/2025/20250310-make-mdb-to-op-master-switch/20250310171450-locations.sparql
+++ b/config/migrations/2025/20250310-make-mdb-to-op-master-switch/20250310171450-locations.sparql
@@ -26,6 +26,14 @@ DELETE {
   }
 }
 WHERE {
+  VALUES ?p {
+    <http://www.w3.org/2000/01/rdf-schema#label>
+    <http://mu.semte.ch/vocabularies/core/uuid>
+    <http://mu.semte.ch/vocabularies/ext/werkingsgebiedNiveau>
+    <http://www.opengis.net/ont/geosparql#sfWithin>
+    <http://www.w3.org/2004/02/skos/core#exactMatc>
+  }
+
   GRAPH <http://mu.semte.ch/graphs/public> {
     ?s a <http://www.w3.org/ns/prov#Location>; ?p ?o
   }
@@ -39,6 +47,13 @@ INSERT {
   }
 }
 WHERE {
+  VALUES ?p {
+    <http://www.w3.org/2000/01/rdf-schema#label>
+    <http://mu.semte.ch/vocabularies/core/uuid>
+    <http://mu.semte.ch/vocabularies/ext/werkingsgebiedNiveau>
+    <http://www.opengis.net/ont/geosparql#sfWithin>
+    <http://www.w3.org/2004/02/skos/core#exactMatc>
+  }
   GRAPH <http://mu.semte.ch/graphs/landing-zone/op-public> {
     ?s a <http://www.w3.org/ns/prov#Location>; ?p ?o
   }

--- a/config/migrations/2025/20250310-make-mdb-to-op-master-switch/20250310171450-locations.sparql
+++ b/config/migrations/2025/20250310-make-mdb-to-op-master-switch/20250310171450-locations.sparql
@@ -31,7 +31,7 @@ WHERE {
     <http://mu.semte.ch/vocabularies/core/uuid>
     <http://mu.semte.ch/vocabularies/ext/werkingsgebiedNiveau>
     <http://www.opengis.net/ont/geosparql#sfWithin>
-    <http://www.w3.org/2004/02/skos/core#exactMatc>
+    <http://www.w3.org/2004/02/skos/core#exactMatch>
   }
 
   GRAPH <http://mu.semte.ch/graphs/public> {
@@ -52,7 +52,7 @@ WHERE {
     <http://mu.semte.ch/vocabularies/core/uuid>
     <http://mu.semte.ch/vocabularies/ext/werkingsgebiedNiveau>
     <http://www.opengis.net/ont/geosparql#sfWithin>
-    <http://www.w3.org/2004/02/skos/core#exactMatc>
+    <http://www.w3.org/2004/02/skos/core#exactMatch>
   }
   GRAPH <http://mu.semte.ch/graphs/landing-zone/op-public> {
     ?s a <http://www.w3.org/ns/prov#Location>; ?p ?o

--- a/config/migrations/2025/20250310-make-mdb-to-op-master-switch/20250310171450-locations.sparql
+++ b/config/migrations/2025/20250310-make-mdb-to-op-master-switch/20250310171450-locations.sparql
@@ -1,0 +1,45 @@
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?s <http://data.vlaanderen.be/ns/besluit#werkingsgebied> ?old
+  }
+}
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?s <http://data.vlaanderen.be/ns/besluit#werkingsgebied> ?new
+  }
+}
+WHERE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?s <http://data.vlaanderen.be/ns/besluit#werkingsgebied> ?old
+  }
+
+  GRAPH <http://mu.semte.ch/graphs/landing-zone/op-public> {
+    ?s <http://data.vlaanderen.be/ns/besluit#werkingsgebied> ?new
+  }
+}
+
+;
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?s a <http://www.w3.org/ns/prov#Location>; ?p ?o
+  }
+}
+WHERE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?s a <http://www.w3.org/ns/prov#Location>; ?p ?o
+  }
+}
+
+;
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?s a <http://www.w3.org/ns/prov#Location>; ?p ?o
+  }
+}
+WHERE {
+  GRAPH <http://mu.semte.ch/graphs/landing-zone/op-public> {
+    ?s a <http://www.w3.org/ns/prov#Location>; ?p ?o
+  }
+}

--- a/config/migrations/2025/20250310122511-bestuursfunctie.sparql
+++ b/config/migrations/2025/20250310122511-bestuursfunctie.sparql
@@ -1,0 +1,14 @@
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+     ?s a <http://lblod.data.gift/vocabularies/organisatie/BestuursfunctieCode>,
+       <http://mu.semte.ch/vocabularies/ext/BestuursfunctieCode>;
+       ?p ?o.
+  }
+
+}
+WHERE {
+   GRAPH <http://mu.semte.ch/graphs/landing-zone/op-public> {
+     ?s a <http://lblod.data.gift/vocabularies/organisatie/BestuursfunctieCode>;
+       ?p ?o.
+   }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -207,7 +207,7 @@ services:
   # OP PUBLIC CONSUMER
   ################################################################################
   op-public-consumer:
-    image: lblod/delta-consumer:0.0.27
+    image: lblod/delta-consumer:0.1.4
     environment:
       DCR_SERVICE_NAME: "op-public-consumer"
       DCR_SYNC_BASE_URL: "https://organisaties.abb.lblod.info" # replace with link to OP API


### PR DESCRIPTION
We're switching around de producer configuration. Organizations becomes master of data that was previously 'fake mastered' by loket. Here we make sure, all mappings are still correct See also: DL-6496